### PR TITLE
Add gitpod config

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,10 @@
+FROM node:12
+                    
+USER gitpod
+
+# Install custom tools, runtime, etc. using apt-get
+# For example, the command below would install "bastet" - a command line tetris clone:
+#
+# RUN sudo apt-get -q update && #     sudo apt-get install -yq bastet && #     sudo rm -rf /var/lib/apt/lists/*
+#
+# More information: https://www.gitpod.io/docs/config-docker/

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,10 +1,3 @@
-FROM node:12
-                    
-USER gitpod
+FROM node:12.16.0-buster
 
-# Install custom tools, runtime, etc. using apt-get
-# For example, the command below would install "bastet" - a command line tetris clone:
-#
-# RUN sudo apt-get -q update && #     sudo apt-get install -yq bastet && #     sudo rm -rf /var/lib/apt/lists/*
-#
-# More information: https://www.gitpod.io/docs/config-docker/
+USER gitpod

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,4 @@
+tasks:
+  - init: npm install
+image:
+  file: .gitpod.Dockerfile

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/theghostbel/gdocs-table-downloader) 
+
 # gdocs-table-downloader
 
 [![Node.js CI](https://github.com/theghostbel/gdocs-table-downloader/workflows/Node.js%20CI/badge.svg)](https://github.com/theghostbel/gdocs-table-downloader/actions)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/theghostbel/gdocs-table-downloader) 
+
 
 # gdocs-table-downloader
 
 [![Node.js CI](https://github.com/theghostbel/gdocs-table-downloader/workflows/Node.js%20CI/badge.svg)](https://github.com/theghostbel/gdocs-table-downloader/actions)
 [![npm version](https://badge.fury.io/js/gdocs-table-downloader.svg)](https://www.npmjs.com/package/gdocs-table-downloader)
 [![dependencies](https://david-dm.org/theghostbel/gdocs-table-downloader.svg)](https://github.com/theghostbel/gdocs-table-downloader/blob/master/package.json)
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/theghostbel/gdocs-table-downloader)


### PR DESCRIPTION
This commit adds support for Gitpod.io, a free automated dev environment that makes contributing and generally working on GitHub projects much easier. It allows anyone to start a ready-to-code dev
environment for any branch, issue and pull request with a single click.